### PR TITLE
execve로 프로세스 전환 전 still reachable 정리

### DIFF
--- a/execute/command.c
+++ b/execute/command.c
@@ -60,7 +60,11 @@ int	fork_and_exec(t_data *data, t_cmd *cmd, char *cmd_path)
 		return (free(cmd_path), 1);
 	}
 	if (pid == 0)
+	{
+		free_cmd_list(cmd);
+		free_env_list(data->env);
 		exec_after_fork(cmd_path, args, envp);
+	}
 	free(cmd_path);
 	free_split(envp);
 	free_split(args);

--- a/execute/command.c
+++ b/execute/command.c
@@ -61,6 +61,7 @@ int	fork_and_exec(t_data *data, t_cmd *cmd, char *cmd_path)
 	}
 	if (pid == 0)
 	{
+		rl_clear_history();
 		free_cmd_list(cmd);
 		free_env_list(data->env);
 		exec_after_fork(cmd_path, args, envp);

--- a/execute/exec.c
+++ b/execute/exec.c
@@ -99,12 +99,19 @@ void	exec_child(t_data *data, t_cmd *head, t_pipes *pipeline, int i)
 			exit_child(data, head, pipeline, 127));
 	envp = env_to_array(data->env);
 	args = get_execve_args(cmd);
+	rl_clear_history();
+	free_cmd_list(head);
+	free_pipeline(pipeline);
+	free_env_list(data->env);
 	execve(path, args, envp);
-	print_error(data, cmd->cmd, errno, 126);
+	if (args)
+		print_error(data, args[0], errno, 126);
+	else
+		print_error(data, "execve", errno, 126);
 	free(path);
 	free_split(args);
 	free_split(envp);
-	exit_child(data, head, pipeline, 126);
+	exit(126);
 }
 
 int	execute_pipeline(t_data *data, t_cmd *cmd)

--- a/execute/pipe.c
+++ b/execute/pipe.c
@@ -26,17 +26,20 @@ static void	no_pipe_child(t_data *data, t_cmd *cmd)
 	signal(SIGINT, SIG_DFL);
 	if (prepare_heredoc(data, cmd) == -1)
 	{
+		rl_clear_history();
 		free_cmd_list(cmd);
 		clean_up(data, NULL);
 		exit(1);
 	}
 	if (apply_redir(data, cmd->redir) == -1)
 	{
+		rl_clear_history();
 		free_cmd_list(cmd);
 		clean_up(data, NULL);
 		exit(1);
 	}
 	status = execute_command(data, cmd);
+	rl_clear_history();
 	free_cmd_list(cmd);
 	free_env_list(data->env);
 	exit(status);


### PR DESCRIPTION
- exec_child
- fork_and_exec
에서 
execve 전에 받아온 힙 메모리들을 전부 정리함